### PR TITLE
Slimming Down the Protocol Document

### DIFF
--- a/page/module/local.ejs
+++ b/page/module/local.ejs
@@ -55,7 +55,7 @@
 
         <p>The <dfn>SendLocal</dfn> operation publish payloads to local outlets. It responds to an HTTP GET request on the <var>/local/payloads</var> route, as outlined herein, with a JSON formatted array of <a href="module/payload#localpayload"><var>LocalPayload</var> (Payload Module)</a> objects, unless an error is encountered, in which case it throws a 4xx or 5xx Error Response.</p>
 
-        <p data-status="non-normative">This operation must be used intra-system only. Inter-system sharing of payloads occurs via the <a href="module/publisher#sendout"><var>SendOut</var> (Publisher Module)</a> operation.</p>
+        <p>This operation must be used intra-system only. Inter-system sharing of payloads occurs via the <a href="module/publisher#sendout"><var>SendOut</var> (Publisher Module)</a> operation.</p>
 
         <section data-requirement="must">
 
@@ -137,45 +137,6 @@
 
         <section data-requirement="must">
 
-            <h1 data-ref="sendlocal-one">SendLocal-One</h1>
-
-            <p>The <dfn>SendLocal-One</dfn> operation publishes a payload identified by an <var>(APP_UID, ORIGINATOR_UUID)</var> tuple to local outlets within the autonomous system.</p>
-
-            <section>
-
-                <h1>Request</h1>
-
-                <p>This operation responds to an HTTP GET request on the <var>/local/payloads/ORIGINATOR_UUID/APP_UID</var> route, where <dfn>ORIGINATOR_UUID</dfn> is the UUID of the engine that introduced the payload to the network and <dfn>APP_UID</dfn> is the UID of the app in the context of the originating engine.</p>
-
-            </section>
-
-            <section>
-
-                <h1>Success Response</h1>
-
-                <p>If the engine will fulfill the request, it must reply with a <var>200 Success</var> response with a JSON-formatted message body containing a <a href="module/payload#localpayload"><var>LocalPayload</var> (Payload Module)</a> object.</p>
-
-            </section>
-
-            <section>
-
-                <h1>Error Response</h1>
-
-                <p>If the engine will not fulfill the request, it must reply with a <var>Client Error 4xx</var> or a <var>Server Error 5xx</var>. In addition to the status codes recommended in <a href="#sendlocal-response-error">SendLocal: Error Response</a>, it should throw:</p>
-
-                <dl>
-                    <dt>400 Bad Request</dt>
-                    <dd>The request path contains a malformed <var>(APP_UID, ORIGINATOR_UUID)</var> tuple.</dd>
-                    <dt>404 Not Found</dt>
-                    <dd>No payload exists identified by the <var>(APP_UID, ORIGINATOR_UUID)</var> tuple.</dd>
-                </dl>
-
-            </section>
-
-        </section>
-
-        <section data-requirement="must">
-
             <h1 data-ref="sendlocal-all">SendLocal-All</h1>
 
             <p>The <dfn>SendLocal-All</dfn> operation publishes all payloads to local outlets within the autonomous system.</p>
@@ -221,6 +182,45 @@
 
         </section>
 
+        <section data-requirement="must">
+
+            <h1 data-ref="sendlocal-one">SendLocal-One</h1>
+
+            <p>The <dfn>SendLocal-One</dfn> operation publishes a payload identified by an <var>(APP_UID, ORIGINATOR_UUID)</var> tuple to local outlets within the autonomous system.</p>
+
+            <section>
+
+                <h1>Request</h1>
+
+                <p>This operation responds to an HTTP GET request on the <var>/local/payloads/ORIGINATOR_UUID/APP_UID</var> route, where <dfn>ORIGINATOR_UUID</dfn> is the UUID of the engine that introduced the payload to the network and <dfn>APP_UID</dfn> is the UID of the app in the context of the originating engine.</p>
+
+            </section>
+
+            <section>
+
+                <h1>Success Response</h1>
+
+                <p>If the engine will fulfill the request, it must reply with a <var>200 Success</var> response with a JSON-formatted message body containing a <a href="module/payload#localpayload"><var>LocalPayload</var> (Payload Module)</a> object.</p>
+
+            </section>
+
+            <section>
+
+                <h1>Error Response</h1>
+
+                <p>If the engine will not fulfill the request, it must reply with a <var>Client Error 4xx</var> or a <var>Server Error 5xx</var>. In addition to the status codes recommended in <a href="#sendlocal-response-error">SendLocal: Error Response</a>, it should throw:</p>
+
+                <dl>
+                    <dt>400 Bad Request</dt>
+                    <dd>The request path contains a malformed <var>(APP_UID, ORIGINATOR_UUID)</var> tuple.</dd>
+                    <dt>404 Not Found</dt>
+                    <dd>No payload exists identified by the <var>(APP_UID, ORIGINATOR_UUID)</var> tuple.</dd>
+                </dl>
+
+            </section>
+
+        </section>
+
         <section data-requirement="may">
 
             <h1 data-ref="sendlocal-query">SendLocal-Query</h1>
@@ -237,170 +237,21 @@
 
             </section>
 
-        </section>
+            <section>
 
-    </section>
+                <h1>Error Response</h1>
 
-    <section data-requirement="may">
-
-        <h1 data-ref="localstore">LocalStore</h1>
-
-        <p>The <dfn>LocalStore</dfn> structure is a persistent data store that contains <a href='module/payloads#localpayload'><var>LocalPayload</var> (Payload Module)</a> objects. A payload stored in this structure must have been processed through <a href='#adjintransform'><var>AdjInTransform</var></a> or be created locally.</p>
-
-        <p data-status="non-normative">Except when originated locally, payloads entered into this structure come from <a href="#module/receiver#adjinstore"><var>AdjInStore</var> (Receiver Module)</a> after passing through <a href='#adjintransform'><var>AdjInTransform</var></a>.</p>
-
-        <section data-requirement='must'>
-
-            <h1>Required Operations</h1>
-
-            <p>This structure must support two operations:</p>
-
-            <dl>
-                <dt data-ref='localstore-create'>LocalStore::create(LocalPayload)</dt>
-                <dd>Stores a new record in persistence; must not create a record if any record already exists in persistence with the same <var>identity</var> as the new record. Payloads passed to <var>create</var> must either be originated locally or be passed through <var>AdjInTransform.</var></dd>
-                <dt data-ref='localstore-get'>LocalStore::get(PayloadIdentity)</dt>
-                <dd>Gets a record from persistence that matches the <a href='module/payload#payloadidentity'><var>PayloadIdentity</var> (Payload Module)</a> passed to this method, or if no identity is passed, returns all payloads; must return false if identity was specified and no payload exists matching identity.</dd>
-                <dt data-ref='localstore-get_all'>LocalStore::get_all()</dt>
-                <dd>Gets all records from persistence as an array of objects; must return an empty array if no payloads exist in persistence.</dd>
-            </dl>
-
-            <p data-status='non-normative'>This structure will not store two payloads with identical <var>identity</var> sections.</p>
-
-            <p>The <var>create</var> operation must not be used in any way except as defined by this protocol and its modules.</p>
-
-        </section>
-
-        <section data-requirement='should'>
-
-            <h1>Additional Operations</h1>
-
-            <p>This structure should support two additional operations:</p>
-
-            <dl>
-                <dt data-ref='localstore-update'>LocalStore::update(LocalPayload)</dt>
-                <dd>Updates an existing payload record in persistence; must identify the payload to update by finding an existing record in persistence with the same <var>identity</var> attribute.</dd>
-                <dt data-ref='localstore-get'>LocalStore::delete(PayloadIdentity)</dt>
-                <dd>Deletes a record from persistence that matches the <a href='module/payload#payloadidentity'><var>PayloadIdentity</var> (Payload Module)</a> passed to this method.</dd>
-                <dt data-ref='localstore-get_query'>LocalStore::get_query(string)</dt>
-                <dd>Filtering by a string passed as an argument, gets a subset of records from persistence as an array of objects; must return an empty array if no payloads exist in persistence.</dd>
-                <dt data-ref='localstore-get_search'>LocalStore::get_search(mixed)</dt>
-                <dd>Filtering by query object as defined by the particular storage method, gets a subset of records from persistence as an array of objects; must return an empty array if no payloads exist in persistence.</dd>
-            </dl>
-
-            <p>To change the values of a payload not originated from the engine itself, use <a href='#adjintransform'><var>AdjInTransform</var></a>. A payload not originated from the engine itself must never be updated directly within this structure.</p>
-
-            <p>The <var>delete</var> operation should be used to prune out stale entries.</p>
-
-            <p>The <var>update</var> and <var>delete</var> operations must not be used in any way except as defined by this protocol and its modules.</p>
-
-    </section>
-    
-    <section data-requirement="may">
-        
-        <h1 data-ref="localin">LocalIn</h1>
-        
-        <footer>
-            
-            <section data-requirement="must">
-                
-                <h1>Requirements</h1>
-        
-                <p>The following specifications must be implemented with this sub-module:</p>
+                <p>If the engine will not fulfill the request, it must reply with a <var>Client Error 4xx</var> or a <var>Server Error 5xx</var>. In addition to the status codes recommended in <a href="#sendlocal-response-error">SendLocal: Error Response</a>, it should throw:</p>
 
                 <dl>
-                    <dt><a href="module/receiver#receivein">CASA Protocol Receiver Module - ReceiveIn</a></dt>
-                    <dd>Must implement ReceiveIn; may implement with access control.</dd>
-                    <dt><a href="module/receiver#adjintranslate">CASA Protocol Receiver Module - AdjInTranslate</a></dt>
-                    <dd>Must implement AdjInTranslate.</dd>
-                    <dt><a href="module/receiver#adjinsquash">CASA Protocol Receiver Module - AdjInSquash</a></dt>
-                    <dd>Must implement AdjInSquash.</dd>
-                    <dt><a href="module/receiver#adjinsquash">CASA Protocol Receiver Module - AdjInFilter</a></dt>
-                    <dd>Must implement AdjInFilter; may implement with custom rules.</dd>
-                    <dt><a href="module/receiver#adjinstore">CASA Protocol Receiver Module - AdjInStore</a></dt>
-                    <dd>Must implement AdjInStore.</dd>
-                    <dt><a href="module/local#localstore">CASA Protocol Receiver Module - LocalStore</a></dt>
-                    <dd>Must implement LocalStore.</dd>
+                    <dt>501 Not Implemented</dt>
+                    <dd>The engine does not support the query language.</dd>
                 </dl>
-                
-            </section>
-            
-        </footer>
-        
-        <section data-requirement="must">
-            
-            <h1>AdjInStoreToLocalStore</h1>
-
-            <p>The <dfn>AdjInStoreToLocalStore</dfn> data path delivers payloads from the <a href="module/receiver#adjinstore"><var>AdjInStore</var> (Receiver Module)</a> into <a href="#localstore"><var>LocalStore</var></a>.</p>
-
-            <p>This operation may simply copy payloads from <var>AdjInStore</var> to <var>LocalStore</var> or it may pass payloads from <var>AdjInStore</var> through <var>AdjInTransform</var> before storing them in <var>LocalStore</var>.</p>
-
-        </section>
-        
-        <section data-requirement="may">
-            
-            <h1>AdjInTransform</h1>
-
-            <p>The <dfn>AdjInTransform</dfn> operation makes changes to all payloads received from peers. This operation may be performed over any payload from <var>AdjInStore</var>. For transformations performed, it may update the journal.</p>
-
-            <p data-status="non-normative">Updating the journal during <var>AdjInTransform</var> only affects payloads locally and will not propagate to peers. Consequently, it is not required. To make changes to payloads that propagate beyond the node, use <a href="module/relay#adjouttransform"><var>AdjOutTransform</var> (Relay Module)</a> instead.</p>
 
             </section>
-            
-        </section>
-        
-    </section>
-    
-    <section data-requirement="may">
-        
-        <h1 data-ref="localout">LocalOut</h1>
-        
-        <footer>
-            
-            <section data-requirement="must">
-                
-                <h1>Requirements</h1>
-        
-                <p>The following specifications must be implemented with this sub-module:</p>
-
-                <dl>
-                    <dt><a href="module/relay#adjouttranslate">CASA Protocol Relay Module - AdjOutTranslate</a></dt>
-                    <dd>Must implement AdjOutTranslate.</dd>
-                    <dt><a href="module/relay#adjoutfilter">CASA Protocol Relay Module - AdjOutFilter</a></dt>
-                    <dd>Must implement AdjOutFilter; may implement with custom rules.</dd>
-                    <dt><a href="module/relay#adjouttransform">CASA Protocol Relay Module - AdjOutTransform</a></dt>
-                    <dd>Must implement AdjOutTransform; may implement with custom rules.</dd>
-                    <dt><a href="module/relay#adjoutstore">CASA Protocol Receiver Module - AdjOutStore</a></dt>
-                    <dd>Must implement AdjOutStore.</dd>
-                    <dt><a href="module/local#localstore">CASA Protocol Receiver Module - LocalStore</a></dt>
-                    <dd>Must implement LocalStore.</dd>
-                </dl>
-                
-            </section>
-            
-        </footer>
-        
-        <section data-requirement="must">
-            
-            <h1>LocalStoreToAdjOutStore</h1>
-
-            <p>The <dfn>LocalStoreToAdjOutStore</dfn> data path delivers payloads originated locally from <a href="#localstore"><var>LocalStore</var></a> into <a href="#localstore"><var>AdjOutStore</var></a>.</p>
-
-            <p>The data path for this operation:</p>
-
-            <ol>
-                <li>
-                    For each payload with <var>identity.originator_id</var> equal to the engine's ID:
-                    <ol>
-                        <li>Must transform attributes via <a href="module/relay#adjouttransform"><var>AdjOutTransform</var></a>; may transform with custom rules;</li>
-                        <li>May store within <a href="#adjoutstore">AdjOutStore</a></li>
-                    </ol>
-                </li>
-            </ol>
-
-            <p>This operation must not copy any payloads that did not originate from this engine.</p>
 
         </section>
-        
+
     </section>
 
 </main>

--- a/page/module/payload.ejs
+++ b/page/module/payload.ejs
@@ -67,17 +67,143 @@
         
     </section>
     
+    <section data-requirement="must">
+        
+        <h1>TransitPayload</h1>
+        
+        <section>
+            
+            <h1 data-ref="transitpayload-components">Components</h1>
+        
+            <section data-requirement="must">
+
+                <h1>TransitPayload.identity</h1>
+                
+                <p>The <var>identity</var> property must be set and must conform to the <a href="module/payload#payloadidentity"><var>PayloadIdentity</var></a> definition.</p>
+
+            </section>
+
+            <section data-requirement="must">
+
+                <h1>TransitPayload.original</h1>
+                
+                <p>The <var>original</var> property must be set and must conform to the <a href="module/payload#payloadtransitattributes"><var>PayloadTransitAttributes</var></a> definition.</p>
+                
+                <section data-status="non-normative">
+                    
+                    <p>When converting from <var>LocalPayload</var> to <var>TransitPayload</var>, if the payload originated within the system, it may not include an <var>original</var> property. If this is the case, then the <var>LocalPayload.attributes</var> property should be renamed to the <var>original</var> property as part of the conversion.</p>
+                    
+                </section>
+
+            </section>
+
+            <section data-requirement="may">
+
+                <h1>TransitPayload.journal</h1>
+                
+                <p>The <var>journal</var> property may be set. If it is set, it must be an array of zero or more objects conforming to the <a href="module/payload#payloadtransitjournalentry"><var>PayloadTransitJournalEntry</var></a> definition.</p>
+
+            </section>
+
+            <section data-requirement="may">
+
+                <h1>TransitPayload.attributes</h1>
+                
+                <p>The <var>attributes</var> property may be set. If it is set, it must conform to the <a href="module/payload#payloadtransitattributes"><var>PayloadTransitAttributes</var></a> definition.</p>
+                
+                <section data-status="non-normative">
+                    
+                    <p>The <var>attributes</var> property may be regarded by the <a href="module/receiver">Receiver Module</a>, or the <a href="module/receiver">Receiver Module</a> may compute the attributes structure via the <a href="module/receiver#adjinsquash">AdjInSquash</a> operation.</p>
+                    
+                </section>
+
+            </section>
+            
+        </section>
+        
+        <section>
+            
+            <h1 data-ref="transitpayload-schema">Schema</h1>
+
+            <pre data-schema="TransitPayload"></pre>
+            
+        </section>
+        
+    </section>
+    
+    <section data-requirement="must">
+        
+        <h1>LocalPayload</h1>
+                
+        <p>This structure should be used within the boundaries of a system, but this structure must not be conveyed between systems.</p>
+        
+        <section>
+            
+            <h1 data-ref="localpayload-components">Components</h1>
+        
+            <section data-requirement="must">
+
+                <h1>LocalPayload.identity</h1>
+                
+                <p>The <var>identity</var> property must be set and must conform to the <a href="module/payload#payloadidentity"><var>PayloadIdentity</var></a> definition.</p>
+
+            </section>
+
+            <section data-requirement="should">
+
+                <h1>LocalPayload.original</h1>
+                
+                <p>The <var>original</var> property should be set. If it is set, it must conform to the <a href="module/payload#payloadlocalattributes"><var>PayloadLocalAttributes</var></a> definition.</p>
+
+            </section>
+
+            <section data-requirement="may">
+
+                <h1>LocalPayload.journal</h1>
+                
+                <p>The <var>original</var> property may be set. If it is set, it must be an array of zero or more objects conforming to the <a href="module/payload#payloadlocaljournalentry"><var>PayloadLocalJournalEntry</var></a> definition.</p>
+
+            </section>
+
+            <section data-requirement="must">
+
+                <h1>LocalPayload.attributes</h1>
+                
+                <p>The <var>attributes</var> property must be set and must conform to the <a href="module/payload#payloadlocalattributes"><var>PayloadLocalAttributes</var></a> definition.</p>
+
+            </section>
+                
+            <section data-status="non-normative">
+                
+                <h1>Reduced Structure</h1>
+
+                <p>The <var>original</var> and <var>journal</var> properties, even if known, may not be sent via the <a href="module/local#sendlocal">SendLocal (Local Module)</a> operation to an outlet. This is because, unless the implementation decides otherwise, the <var>original</var> and <var>journal</var> properties are not necessarily relevant within the context of the system after the <a href="module/receiver#adjinsquash">AdjInSquash (Receiver Module)</a> operation computes the <var>attributes</var> property.</p>
+
+            </section>
+            
+        </section>
+        
+        <section>
+            
+            <h1 data-ref="localpayload-schema">Schema</h1>
+
+            <pre data-schema="LocalPayload"></pre>
+            
+        </section>
+        
+    </section>
+    
     <section>
         
         <h1>Payload Sub-structures</h1>
     
-        <section data-requirement="must">
+        <section>
 
             <h1>PayloadIdentity</h1>
             
             <p>The <dfn>PayloadIdentity</dfn> structure is a compound key containing an <var>originator_id</var> UUID property, corresponding to the UUID of the system that created the payload (the "originator"), and an <var>id</var> UID property, corresponding to the logical entity represented by the payload.</p>
             
-            <p data-status="non-normative">The unchanging nature of the <var>PayloadIdentity</var> allows payloads to be introduced into the network that modify any attribute of a payload, including its URI. This ability to modify the attributes of a logical entity is important in the case that the properties of local entity change over its lifetime.</p>
+            <p data-status="non-normative">The unchanging nature of the <var>PayloadIdentity</var> allows the originator to introduce new payloads into the network that modify any attribute of the logical entity, including its URI. This ability to modify the attributes of a logical entity is important in the case that the properties of a logical entity change over its lifetime.</p>
             
             <section>
 
@@ -85,7 +211,7 @@
 
                 <p>The <dfn id="PayloadIdentity-originator_id"><var>originator_id</var></dfn> property must be the UUID of the system that created the payload. The UUID must conform to RFC 4122, and it is recommended that a system sign all payloads it creates with the same <var>originator_id</var> value.</p>
 
-                <p>The <dfn id="PayloadIdentity-id"><var>id</var></dfn> property must be a string that uniquely identifies the local entity represented by the payload among all logical entities created by the system.</p>
+                <p>The <dfn id="PayloadIdentity-id"><var>id</var></dfn> property must be a string that uniquely identifies the logical entity represented by the payload among all logical entities created by the same originator.</p>
 
             </section>
         
@@ -99,7 +225,7 @@
 
         </section>
 
-        <section data-requirement="should">
+        <section>
 
             <h1>PayloadAttributes</h1>
             
@@ -109,11 +235,11 @@
             
                 <p>Attributes are used in a number of contexts: the <var>original</var> section of a payload contains metadata about a payload at the time the payload was created; the <var>journal</var> section of a payload contains an array of entries that specify modifications made to attributes during the payload's lifetime; and the <var>attributes</var> section of a payload contains metadata about a payload once the <var>original</var> and <var>journal</var> sections have been parsed.</p>
 
-                <p>An attributes section has a number of properties. All properties besides <var>use</var> and <var>require</var> must be specified on any attributes object. The <var>use</var> property is an optional object that, if set, contains key-value pairs that may be regarded by a system. The <var>require</var> property is an optional object that, if set, contains key-value pairs that must be regarded by a system. During inter-system communication, the keys of the <var>use</var> and <var>require</var> objects must be UUIDs to ensure for long-term extensibility, but within the boundaries of a system, they may be mapped to human-readable equivalents.</p>
+                <p>An attributes section has a number of properties. The <var>use</var> property is an optional object that, if set, contains key-value pairs that may be regarded by a system. The <var>require</var> property is an optional object that, if set, contains key-value pairs that must be regarded by a system. During inter-system communication, the keys of the <var>use</var> and <var>require</var> objects must be UUIDs to ensure for long-term extensibility, but within the boundaries of a system, they may be mapped to human-readable equivalents.</p>
                 
             </section>
 
-            <section data-requirement="must">
+            <section>
 
                 <h1 data-ref="PayloadAbstractAttributes">Abstract</h1>
             
@@ -125,9 +251,9 @@
 
                     <p>The <dfn id="PayloadAbstractAttributes.timestamp">timestamp</dfn> property must be set as a timestamp conforming to RFC 3339.</p>
 
-                    <p data-status="non-normative">The <var>timestamp</var> attribute denotes when the attributes section was created. When contained within the payload <var>original</var> section, it denotes when the payload was introduced into the network; when contained within the <var>attributes</var> section, it denotes the timestamp of the last entry in the journal that affected changes to the computed attributes section.</p>
+                    <p data-status="non-normative">The <var>timestamp</var> attribute denotes when the attributes section was created. When contained within the payload <var>original</var> section, it denotes when the payload was introduced into the network; when contained within the <var>attributes</var> section, it denotes the timestamp of the last entry in the journal that affected changes to the computed attributes section, or else the same timestamp as the <var>original</var> section if there was no journal or no entries in the journal affected changes to the attributes.</p>
 
-                    <p>The <dfn id="PayloadAbstractAttributes.uri">uri</dfn> property must be set and must define the URI of the logical entity represented by the payload.</p>
+                    <p>The <dfn id="PayloadAbstractAttributes.uri">uri</dfn> property must be set and defines the URI of the logical entity represented by the payload.</p>
 
                     <p>The <dfn id="PayloadAbstractAttributes.share">share</dfn> property may be set and denotes whether a payload should be shared.</p>
 
@@ -149,7 +275,7 @@
                 
             </section>
 
-            <section data-requirement="should">
+            <section>
 
                 <h1 data-ref="PayloadLocalAttributes">Local</h1>
             
@@ -183,7 +309,7 @@
 
             </section>
 
-            <section data-requirement="should">
+            <section>
 
                 <h1 data-ref="PayloadTransitAttributes">Transit</h1>
             
@@ -219,7 +345,7 @@
 
         </section>
 
-        <section data-requirement="should">
+        <section>
 
             <h1>PayloadJournal</h1>
             
@@ -231,7 +357,7 @@
 
             </section>
 
-            <section data-requirement="must">
+            <section>
 
                 <h1 data-ref="PayloadAbstractJournalEntry">Abstract</h1>
             
@@ -259,7 +385,7 @@
 
             </section>
  
-           <section data-requirement="should">
+           <section>
 
                 <h1 data-ref="PayloadLocalJournalEntry">Local</h1>
                 
@@ -293,7 +419,7 @@
 
             </section>
 
-            <section data-requirement="should">
+            <section>
 
                 <h1 data-ref="PayloadTransitJournalEntry">Transit</h1>
             
@@ -325,132 +451,6 @@
 
             </section>
 
-        </section>
-        
-    </section>
-    
-    <section data-requirement="must">
-        
-        <h1>TransitPayload</h1>
-        
-        <section>
-            
-            <h1 data-ref="transitpayload-components">Components</h1>
-        
-            <section data-requirement="must">
-
-                <h1>TransitPayload.identity</h1>
-                
-                <p>The <var>identity</var> property must be set and must conform to the <var>PayloadIdentity</var> definition.</p>
-
-            </section>
-
-            <section data-requirement="must">
-
-                <h1>TransitPayload.original</h1>
-                
-                <p>The <var>original</var> property must be set and must conform to the <var>PayloadTransitAttributes</var> definition.</p>
-                
-                <section data-status="non-normative">
-                    
-                    <p>When converting from <var>LocalPayload</var> to <var>TransitPayload</var>, if the payload originated within the system, it may not include an <var>original</var> property. If this is the case, then the <var>LocalPayload.attributes</var> property should be renamed to the <var>original</var> property as part of the conversion.</p>
-                    
-                </section>
-
-            </section>
-
-            <section data-requirement="may">
-
-                <h1>TransitPayload.journal</h1>
-                
-                <p>The <var>journal</var> property may be set. If it is set, it must be an array of zero or more objects conforming to the <var>PayloadTransitJournalEntry</var> definition.</p>
-
-            </section>
-
-            <section data-requirement="should-not" data-status="editor-challenged" data-message="This section might better qualify as a <u>may</u> than a <u>should not</u>. There's nothing wrong with sharing the local perception of attributes. This would allow a peer to skip, if it so chose, actually doing AdjInSquash.">
-
-                <h1>TransitPayload.attributes</h1>
-                
-                <p>The <var>attributes</var> property should not be set. If it is set, it must conform to the <var>PayloadTransitAttributes</var> definition.</p>
-                
-                <section data-status="non-normative">
-                    
-                    <p>The <var>attributes</var> property is ignored by the <a href="module/receiver">Receiver Module</a>; instead of using this property, it computes an attributes structure via the <a href="module/receiver#adjinsquash">AdjInSquash</a> operation.</p>
-                    
-                </section>
-
-            </section>
-            
-        </section>
-        
-        <section>
-            
-            <h1 data-ref="transitpayload-schema">Schema</h1>
-
-            <pre data-schema="TransitPayload"></pre>
-            
-        </section>
-        
-    </section>
-    
-    <section data-requirement="must">
-        
-        <h1>LocalPayload</h1>
-                
-        <p>This structure should be used within the boundaries of a system, but this structure must not be conveyed between systems.</p>
-        
-        <section>
-            
-            <h1 data-ref="localpayload-components">Components</h1>
-        
-            <section data-requirement="must">
-
-                <h1>LocalPayload.identity</h1>
-                
-                <p>The <var>identity</var> property must be set and must conform to the <var>PayloadIdentity</var> definition.</p>
-
-            </section>
-
-            <section data-requirement="should">
-
-                <h1>LocalPayload.original</h1>
-                
-                <p>The <var>original</var> property should be set. If it is set, it must conform to the <var>PayloadLocalAttributes</var> definition.</p>
-
-            </section>
-
-            <section data-requirement="may">
-
-                <h1>LocalPayload.journal</h1>
-                
-                <p>The <var>original</var> property may be set. If it is set, it must be an array of zero or more objects conforming to the <var>PayloadLocalJournalEntry</var> definition.</p>
-
-            </section>
-
-            <section data-requirement="must">
-
-                <h1>LocalPayload.attributes</h1>
-                
-                <p>The <var>attributes</var> property must be set and must conform to the <var>PayloadLocalAttributes</var> definition.</p>
-
-            </section>
-                
-            <section data-status="non-normative">
-                
-                <h1>Reduced Structure</h1>
-
-                <p>The <var>original</var> and <var>journal</var> properties, even if known, may not be sent via the <a href="module/local#sendlocal">SendLocal (Local Module)</a> operation to an outlet, unless the <a href="module/manager">Manager Module</a> is implemented and the outlet is identified as a manager. This is because the <var>original</var> and <var>journal</var> properties are not relevant within the context of the system after the <a href="module/receiver#adjinsquash">AdjInSquash (Receiver Module)</a> operation computes the <var>attributes</var> property.</p>
-
-            </section>
-            
-        </section>
-        
-        <section>
-            
-            <h1 data-ref="localpayload-schema">Schema</h1>
-
-            <pre data-schema="LocalPayload"></pre>
-            
         </section>
         
     </section>

--- a/page/module/publisher.ejs
+++ b/page/module/publisher.ejs
@@ -81,6 +81,27 @@
                 <dt><var>Body Content</var></dt>
                 <dd>If the client includes a request body, it must be a JSON-formatted object of key-value pairs. If the client sends any other body content, a 4xx Error must be thrown unless the server understands and processes the body data based on the non-standard <var>Content-Type</var> header sent by the client.</dd>
             </dl>
+
+            <section data-requirement="may">
+
+                <h1 data-ref="sendout-access-controls">Access Control</h1>
+
+                <p>A host may implement access controls for the <var>SendOut</var> operation.</p>
+
+                <p>Two forms of access control are recommended:</p>
+
+                <dl>
+                    <dt>Address-based Access Control</dt>
+                    <dd>Requests are only accepted from certain IP addresses and/or ranges.</dd>
+                    <dt>Secret-based Access Control</dt>
+                    <dd>Requests are only accepted when a valid secret is specified.</dd>
+                </dl>
+
+                <p>If secret-based access control is implemented, the host must accept a secret passed by the name <var>secret</var> in either the HTTP GET request query string or a JSON-encoded request body. It shall not accept a secret through either of these mechanisms unless it accepts the secret through both.</p>
+
+                <p>If a host will not fulfill a <var>SendOut</var> request because of access controls, it must respond with <var>403 Forbidden</var>.</p>
+
+            </section>
             
         </section>
         
@@ -92,7 +113,7 @@
             
             <p>A response body of a <var>200 OK</var> response must be an array of <a href="module/payload#transitpayload"><var>TransitPayload</var> (Payload Module)</a> objects. This response must be JSON-formatted and use the <var>utf-8</var> charset. Consequently, this response should include <var>Content-Type: application/json;charset=utf-8</var> header, although this may be implied by omission. The host must not send any other <var>Content-Type</var> header.</p>
             
-            <p data-status="non-normative">Consult <a href="module/receiver#receivein-success-response"><var>ReceiveIn</var> (Receiver Module)</a> for client-side validation rules. The host must conform to this rules for the response to be accepted.</p>
+            <p data-status="non-normative">Consult <a href="module/receiver#receivein-success-response"><var>ReceiveIn</var> (Receiver Module)</a> for client-side validation rules. The host must conform to these rules for the response to be accepted.</p>
                 
         </section>
         
@@ -107,6 +128,8 @@
             <dl>
                 <dt>400 Bad Request</dt>
                 <dd>The request body contained malformed JSON.</dd>
+                <dt>403 Forbidden</dt>
+                <dd>The host implements access control and the request does not meet requirements.</dd>
                 <dt>406 Not Acceptable</dt>
                 <dd>The request specified a non-conforming <var>Accept</var> or <var>Accept-Charset</var> header.</dd>
                 <dt>415 Unsupported Media Type</dt>
@@ -118,123 +141,6 @@
         
         </section>
         
-    </section>
-        
-    <section data-requirement="may">
-
-        <h1 data-ref="sendout-access-controls">SendOut with Access Controls</h1>
-
-        <p>A host may implement access controls for the <var>SendOut</var> operation.</p>
-        
-        <p>Two forms of access control are recommended:</p>
-        
-        <dl>
-            <dt>Address-based Access Control</dt>
-            <dd>Requests are only accepted from certain IP addresses and/or ranges.</dd>
-            <dt>Secret-based Access Control</dt>
-            <dd>Requests are only accepted when a valid secret is specified.</dd>
-        </dl>
-        
-        <p>If secret-based access control is implemented, the host must accept a secret passed by the name <var>secret</var> in either the HTTP GET request query string or a JSON-encoded request body. It shall not accept a secret through either of these mechanisms unless it accepts the secret through both.</p>
-            
-        <p>If a host will not fulfill a <var>SendOut</var> request because of access controls, it must respond with the status code:</p>
-        
-        <dl>
-            <dt>403 Forbidden</dt>
-            <dd>The host implements access control and the request does not meet requirements.</dd>
-        </dl>
-        
-        <section data-requirement="may">
-
-            <h1 data-ref="adjoutpeer">AdjOutPeer</h1>
-
-            <p>The <dfn>AdjOutPeer</dfn> structure may be implemented to define access controls.</p>
-            
-            <p data-status="non-normative">This structure is useful under complex access controls situations where a host defines a number of systems it may support. For example, this structure is implemented for access controls managed by the <a href="module/manager#OutletReceiveNode"><var>OutletReceiveNode (Manager Module)</var></a> operation.</p>
-            
-            <section>
-                
-                <h1>Attributes</h1>
-                
-                <p>The <dfn id="AdjOutPeer-name">name</dfn> property must be set and must be unique among all <var>AdjOutPeer</var> objects defined within the system. The <var>name</var> property is used to identify a <var>AdjOutPeer</var>. For example, this property is used when creating/updating/deleting <var>AdjOutPeer</var> entities via the <a href="module/manager#OutletReceiveNode"><var>OutletReceiveNode (Manager Module)</var></a> operation.</p>
-                
-                <p>The <var>local</var> property must be set and denotes whether the entity is inter- or intra- system. If this property is <var>true</var>, then the structure is not an <var>AdjOutPeer</var> but rather an <a href="#module/local#outlet"><var>Outlet (Local Module)</var></a>.</p>
-                
-                <p>The <var>secret</var> property may be set. If set, the <var>secret</var> property specifies a string that a client must provide when issuing a request.</p>
-                
-                <p>The <var>address</var> property may be set. If set, the <var>address</var> property must conform to the IP Address format. This property specifies an IP address required for a client to be considered as a match.</p>
-                
-                <p>The <var>mask</var> property may be set. If set, <var>mask</var> property must conform to the IP Address format. This property specifies a wildcard mask applied to <var>address</var>, where any request from a client within the specified range must be considered as matching this structure. This property should not be set if the <var>address</var> property is not set.</p>
-                
-            </section>
-            
-            <section>
-                
-                <h1>Resolving an AdjOutPeer</h1>
-                
-                <p>For each <var>AdjOutPeer</var>, the following routine should be used to determine a match:</p>
-                
-                <ol>
-                    <li>If <var>AdjOutPeer.secret</var> is specified but the request does not include a <var>secret</var> or the request <var>secret</var> does not match, <strong>not a match</strong>.
-                    <li>If <var>AdjOutPeer.address</var> is not specified, <strong>match</strong>.</li>
-                    <li>Unless <var>AdjOutPeer.mask</var> is specified:
-                        <ol>
-                            <li>If <var>AdjOutPeer.address</var> equals the the requesting client IP address, <strong>match</strong>.</li>
-                            <li>Otherwise, <strong>not a match.</strong></li>
-                        </ol>
-                    </li>
-                    <li>Apply <var>AdjOutPeer.mask</var> as a subnet mask over <var>AdjOutPeer.out.address</var> and the requesting client IP address:
-                        <ol>
-                            <li>If the addresses are equal once the mask is applied, <strong>match</strong>.</li>
-                            <li>Otherwise, <strong>not a match.</strong></li>
-                        </ol>
-                    </li>
-                </ol>
-                
-                <section data-status='non-normative'>
-                    
-                    <h1>Implementation Example</h1>
-                
-                    <pre data-lang="ruby"># Assume: request object with:
-#  - secret: string (from request query string or JSON-encoded body)
-#  - ip: string (IP Address format from requesting user agent)
-# Assume: AdjOutPeer array of objects with:
-#  - secret: string or false
-#  - address: string (IP Address format) or false
-#  - mask: string (IP address format) or false
-
-matches = adjOutPeers.select { |peer|
-
-  if peer.secret
-    return false unless request.body.secret == peer.secret
-  end
-
-  return true unless peer.address
-  
-  unless peer.mask
-    return IPAddr.new(peer.address) == IPAddr.new(request.ip)
-  else
-
-  return IPAddr.new(peer.address).mask(peer.mask) == IPAddr.new(request.ip).mask(peer.mask)
-
-}</pre>
-                    
-                </section>
-                
-                <p>If the AdjOutPeer mechanism is implemented and no matching AdjOutPeer entries are found, a 403 Error must be thrown.</p>
-                
-            </section>
-
-            <section>
-                
-                <h1>Schema</h1>
-            
-                <pre data-schema="AdjOutPeer"></pre>
-            
-            </section>
-
-        </section>
-
     </section>
     
 </main>

--- a/page/module/receiver.ejs
+++ b/page/module/receiver.ejs
@@ -63,9 +63,9 @@
             <li>
                 Must validate response:
                 <ol>
-                    <li>If invalid <var>Content-Type</var>, abort.</li>
-                    <li>If response body is not valid JSON array, abort.</li>
-                    <li>If an element of JSON array is not valid <a href="module/payload#transitpayload"><var>TransitPayload</var> (Payload Module)</a>, discard element</li>
+                    <li>If invalid <var>Content-Type</var>, abort;</li>
+                    <li>If response body is not a valid JSON array, abort;</li>
+                    <li>If an element of JSON array is not valid <a href="module/payload#transitpayload"><var>TransitPayload</var> (Payload Module)</a>, discard the element.</li>
                 </ol>
             </li>
             <li>
@@ -73,8 +73,7 @@
                 <ol>
                     <li>Must translate via <a href="#adjintranslate"><var>AdjInTranslate</var></a>;</li>
                     <li>Must squash via <a href="#adjinsquash"><var>AdjInSquash</var></a>;</li>
-                    <li>Must pass filtering by <a href="#adjintfilter"><var>AdjInFilter</var></a>; may filter with custom rules;</li>
-                    <li>May store within <a href="#adjinstore"><var>AdjInStore</var></a>.</li>
+                    <li>Must pass filtering by <a href="#adjintfilter"><var>AdjInFilter</var></a>; may filter with custom rules.</li>
                 </ol>
             </li>
         </ol>
@@ -93,7 +92,7 @@
             
             <h1>Request</h1>
             
-            <p>The client must issue an HTTP GET request to the <var>/out/payloads</var> route on the host.</p>
+            <p>The client issues an HTTP GET request to the <var>/out/payloads</var> route on the host.</p>
             
             <p>The client may include a request body. If the request includes a request body, it must be JSON-formatted.</p>
             
@@ -242,7 +241,7 @@
         
         <h1>AdjInSquash</h1>
         
-        <p>The <var>AdjInTranslate</var> operation accepts a <a href="module/payload#transitpayload"><var>TransitPayload</var> (Payload Module)</a> object that must have already been passed through <a href='#adjintranslate'><var>AdjInTranslate</var></a>, and it produces an <a href='#module/payload#localpayload'><var>LocalPayload</var> (Payload Module)</a> by constructing an <var>attributes</var> section from the <var>original</var> property and optionally the <var>journal</var> section, if defined.</p>
+        <p>The <var>AdjInSquash</var> operation accepts an object that must have been a valid <a href="module/payload#transitpayload"><var>TransitPayload</var> (Payload Module)</a> object and must have been passed through <a href='#adjintranslate'><var>AdjInTranslate</var></a>. This operation produces an <a href='#module/payload#localpayload'><var>LocalPayload</var> (Payload Module)</a> by constructing an <var>attributes</var> section from the <var>original</var> property and optionally the <var>journal</var> section, if defined.</p>
         
         <p>This operation must following this algorithm:</p>
         
@@ -312,76 +311,10 @@ end</pre>
         <ol>
             <li>All keys under <var>attributes.require</var> must be recognized.</li>
             <li>All key-value pairs under <var>attributes.require</var> must validate per the <a href='core#attribute-specification'>attribute specification</a> referred to by key.</li>
-            <li>If <a href='#adjinstore'><var>AdjInStore</var></a> is implemented and a payload matching <var>identity</var> already exists in persistence, <var>attributes.timestamp</var> must be more recent than the value in persistence.</li>
+            <li>If the logical entity represented by the payload is tracked in a persistence layer, <var>attributes.timestamp</var> should be more recent than the value in persistence.</li>
         </ol>
         
         <p>An implementation may define additional criteria for this operation.</p>
-
-        <section data-requirement="should" data-status="stub">
-
-            <h1>AdjInFilterRules</h1>
-
-            <p>The <dfn>AdjInFilterRules</dfn> structure may be implemented as a methodology for specifying filter rules.</p>
-            
-            <p data-status="non-normative">While implementations may add <var>AdjInFilter</var> constraints internally, this structure is useful for allowing outlet- or user- defined rules, such as via the <a href="module/manager#OutletReceiveAdjInFilterRules"><var>OutletReceiveAdjInFilterRules (Manager Module)</var></a> operation.</p>
-
-        </section>
-        
-    </section>
-    
-    <section data-requirement="may">
-        
-        <h1>AdjInStore</h1>
-        
-        <p>The <dfn>AdjInStore</dfn> structure is a persistent data store that contains <a href='module/payloads#localpayload'><var>LocalPayload</var> (Payload Module)</a> objects. A payload stored in this structure must be received via <a href='#receivein'><var>ReceiveIn</var></a>, translated by <a href='#adjintranslate'><var>AdjInTranslate</var></a>, squashed by <a href='#adjinsquash'><var>AdjInSquash</var></a> and filtered by <a href='#adjintranslate'><var>AdjInFilter</var></a>.</p>
-        
-        <p data-status='non-normative'>This structure is used by the <a href='module/relay'>Relay Module</a> to generate payloads for inter-system propagation to peers; additionally, this structure is used by the <a href='module/local'>Local Module</a> to present inter-system payloads to intra-system outlets. Both modules use this structure with additional constraints before presenting payloads, so the payloads in this structure are never accessed directly by inter-system peers or intra-system outlets.</p>
-        
-        <section data-requirement='must'>
-            
-            <h1>Required Operations</h1>
-        
-            <p>This structure must support two operations:</p>
-
-            <dl>
-                <dt data-ref='adjinstore-create'>AdjInStore::create(LocalPayload)</dt>
-                <dd>Stores a new record in persistence; must not create a record if any record already exists in persistence with the same <var>identity</var> as the new record.</dd>
-                <dt data-ref='adjinstore-get'>AdjInStore::get(PayloadIdentity)</dt>
-                <dd>Gets a record from persistence that matches the <a href='module/payload#payloadidentity'><var>PayloadIdentity</var> (Payload Module)</a> passed to this method, or if no identity is passed, returns all payloads; must return false if identity was specified and no payload exists matching identity.</dd>
-                <dt data-ref='adjinstore-get_all'>AdjInStore::get_all()</dt>
-                <dd>Gets all records from persistence as an array of objects; must return an empty array if no payloads exist in persistence.</dd>
-            </dl>
-        
-            <p data-status='non-normative'>This structure will not store two payloads with identical <var>identity</var> sections.</p>
-            
-            <p>The <var>create</var> operation must not be used in any way except as defined by this protocol and its modules.</p>
-            
-            <p data-status='non-normative'>To add a payload for propagation via <a href='module/publisher#sendout'><var>SendOut</var> (Publisher Module)</a>, it must either arrive via <var>ReceiveIn</var> or be added to <a href='module/local#localstore'><var>LocalStore</var> (Local Module)</a>. It must not be added directly to <var>AdjInStore</var>, as this implies that the payload arrived from an external source.</p>
-        
-        </section>
-        
-        <section data-requirement='should'>
-            
-            <h1>Additional Operations</h1>
-        
-            <p>This structure should support two additional operations:</p>
-        
-            <dl>
-                <dt data-ref='adjinstore-update'>AdjInStore::update(LocalPayload)</dt>
-                <dd>Updates an existing payload record in persistence; must identify the payload to update by finding an existing record in persistence with the same <var>identity</var> attribute.</dd>
-                <dt data-ref='adjinstore-get'>AdjInStore::delete(PayloadIdentity)</dt>
-                <dd>Deletes a record from persistence that matches the <a href='module/payload#payloadidentity'><var>PayloadIdentity</var> (Payload Module)</a> passed to this method.</dd>
-            </dl>
-            
-            <p>The <var>update</var> and <var>delete</var> operations must not be used in any way except as defined by this protocol and its modules.</p>
-            
-            <p data-status='non-normative'>To change the way a payload is presented via <a href='module/publisher#sendout'><var>SendOut</var> (Publisher Module)</a>, use <a href='module/relay#adjouttransform'><var>AdjOutTransform</var> (Relay Module)</a>. To change the way a payload is presented via <a href='module/local#sendlocal'><var>SendLocal</var> (Local Module)</a>, use <a href='module/local#adjintransform'><var>AdjInTransform</var> (Local Module)</a>.</p>
-        
-            <p>The <var>delete</var> operation should be used to prune out stale entries.</p>
-            
-            <p data-status='non-normative'>To prevent a payload from being presented via <a href='module/publisher#sendout'><var>SendOut</var> (Publisher Module)</a>, use <a href='module/relay#adjoutfilter'><var>AdjOutFilter</var> (Relay Module)</a>. A payload must not be prevented from being presented via <a href='module/local#sendlocal'><var>SendLocal</var> (Local Module)</a> unless it is dropped by <a href='#adjinfilter'><var>AdjInFilter</var></a> prior to this step. This means that a payload must not be relayed via <a href='module/publisher#sendout'><var>SendOut</var> (Publisher Module)</a> unless it is also made available via <a href='module/local#sendlocal'><var>SendLocal</var> (Local Module)</a>.</p>
-            
-        </section>
         
     </section>
     

--- a/page/module/receiver.ejs
+++ b/page/module/receiver.ejs
@@ -111,6 +111,23 @@
                 <dt><var>Content-Type: application/json;charset=utf-8</var></dt>
                 <dd>The client should send this header if the request includes a body section, although it may be implied by omission. The client must not send any other <var>Content-Type</var> header.</dd>
             </dl>
+            <section data-requirement="may">
+
+                <h1 data-ref="receivein-access-controls">Access Control</h1>
+
+                <p>A host may refuse to serve a <var>GET /out/payloads</var> request unless certain access criteria are met. If the request from a client does not meet the host's access criteria, the HTTP response shall be a 4xx Error or 5xx Error and should be a 403 Error.</p>
+
+                <section data-status='non-normative'>
+
+                    <p><a href='module/publisher#sendout-access-controls'>SendOut - Access Controls (Publisher Module)</a> specifies two kinds of access control: <var>address-based</var> and <var>secret-based</var>. The former requires that the client match a certain IP address or range, while the latter requires that the client provide a pre-negotiated <var>secret</var> property via either the query string or a JSON-encoded request body.</p>
+
+                </section>
+
+                <p>If the client has negotiated a <var>secret</var> parameter with the host, it must send this property either by the name <var>secret</var> within the query string or as the property <var>secret</var> within a JSON-encoded object in the request body.</p>
+
+                <p data-status="non-normative">The client should send a <var>Content-Type: application/json</var> header with the request if it includes a <var>secret</var> property within the request body.</p>
+
+            </section>
             
         </section>
         
@@ -158,77 +175,6 @@
             
         </section>
         
-    </section>
-        
-    <section data-requirement="may">
-
-        <h1 data-ref="receivein-access-controls">ReceiveIn with Access Controls</h1>
-
-        <p>A host may refuse to serve a <var>GET /out/payloads</var> request unless certain access criteria are met. If the request from a client does not meet the host's access criteria, the HTTP response shall be a 4xx Error or 5xx Error and should be a 403 Error.</p>
-        
-        <section data-status='non-normative'>
-            
-            <p><a href='module/publisher#sendout-access-controls'>SendOut with Access Controls (Publisher Module)</a> specifies two kinds of access control: <var>address-based</var> and <var>secret-based</var>. The former requires that the client match a certain IP address or range, while the latter requires that the client provide a pre-negotiated <var>secret</var> property via either the query string or a JSON-encoded request body.</p>
-            
-        </section>
-        
-        <p>If the client has negotiated a <var>secret</var> parameter with the host, it must send this property either by the name <var>secret</var> within the query string or as the property <var>secret</var> within a JSON-encoded object in the request body.</p>
-        
-        <p data-status="non-normative">The client should send a <var>Content-Type: application/json</var> header with the request if it includes a <var>secret</var> property within the request body.</p>
-
-        <section data-requirement="should">
-
-            <h1 data-ref="adjoutpeer">AdjInPeer</h1>
-
-            <p>The <dfn>AdjInpeer</dfn> structure may be implemented to define access requirements.</p>
-            
-            <p data-status="non-normative">This structure is useful when managing a number of in-bound peers that the host queries. This structure is implemented for access controls in the <a href="module/manager#OutletReceiveNode"><var>OutletReceiveNode (Manager Module)</var></a> operation.</p>
-
-            <section>
-                
-                <h1>Schema</h1>
-            
-                <pre data-schema="AdjInPeer"></pre>
-            
-            </section>
-            
-            <section data-status='non-normative'>
-                    
-                <h1>Usage Example</h1>
-
-                <pre data-lang="ruby"># Assume: adjInPeers array of AdjInPeer objects
-# Assume: URI, Net::HTTP::Get and Net::HTTP classes
-# Assume: process_response(response) method that:
-#  - validates response
-#  - runs AdjInTranslate -> AdjInSquash -> AdjInFilter
-#  - optionally stores in AdjInStore
-
-adjInPeers.each { |peer|
-
-  uri = URI(peer.uri)
-
-  Net::HTTP.start(uri.host, uri.port) do |http|
-
-    request = Net::HTTP::Get.new("#{uri}/out/payloads")
-
-    request.add_field('Accept', 'application/json')
-    request.add_field('Accept-Charset', 'utf-8')
-    request.add_field('Content-Type', 'application/json')
-
-    if peer.secret
-      request.body = {'secret'=>peer.secret}.to_json
-    end
-
-    process_response(http.request(request))
-
-  end
-
-}</pre>
-
-            </section>
-
-        </section>
-
     </section>
     
     <section data-requirement="must">

--- a/page/module/relay.ejs
+++ b/page/module/relay.ejs
@@ -92,7 +92,7 @@
             <li>If <var>attributes.propagate</var> is <var>false</var>, the value of <var>attributes.share</var> must be set <var>false</var>.</li>
         </ol>
 
-        <p>An implementation may define additional criteria for this operation.</p>
+        <p>An implementation may define additional criteria for this operation. If an implementation intends to change an attribute, it must add an entry in the <var>journal</var> section. This entry must contain the information to perform the transformation, following the attribute specification if defined, or else simply the new value to be copied in. If the implementation sends the <var>attributes</var> section, the value must be changed in that section as well.</p>
 
     </section>
     

--- a/page/module/relay.ejs
+++ b/page/module/relay.ejs
@@ -40,8 +40,6 @@
             <dd>Must implement AdjInSquash.</dd>
             <dt><a href="module/receiver#adjinsquash">CASA Protocol Receiver Module - AdjInFilter</a></dt>
             <dd>Must implement AdjInFilter; may implement with custom rules.</dd>
-            <dt><a href="module/receiver#adjinstore">CASA Protocol Receiver Module - AdjInStore</a></dt>
-            <dd>Must implement AdjInStore.</dd>
         </dl>
         
     </section>
@@ -66,10 +64,9 @@
         <ol>
             <li>Create empty array for payloads response.</li>
             <li>
-                For each payload from <a href="module/receiver#adjinstore"><var>AdjInStore::get()</var> (Receiver Module)</a> with <var>identity.originator_id</var> not equal to the engine id, and for each payload from <a href="module/local#localstore"><var>LocalStore::get()</var> (Local Module)</a> with <var>identity.originator_id</var> equal to the engine id:
+                For each known payload:
                 <ol>
                     <li>Must transform attributes via <a href="#adjouttransform"><var>AdjOutTransform</var></a>; may transform with custom rules;</li>
-                    <li>May store within <a href="#adjoutstore">AdjOutStore</a>;</li>
                     <li>Must pass filtering by <a href="#adjoutfilter"><var>AdjOutFilter</var></a>; may filter with custom rules;</li>
                     <li>Must translate via <a href="#adjouttranslate">AdjOutTranslate</a>;</li>
                     <li>Should append to payloads response array</li>
@@ -87,80 +84,16 @@
         <h1>AdjOutTransform</h1>
         
         <p>The <dfn>AdjOutTransform</dfn> operation makes changes to all payloads before they are shared outbound. This operation must be performed over any payload before it may be conveyed beyond the boundaries of the system.</p>
-        
-        <section data-status="conflict" data-message="By implication, this section is in conflict with <a href='module/payload#transitpayload-attributes'><var>TransitPayload.attributes</var> (Payload Module)</a> because it does nothing to remove the <var>attributes</var> section that is marked as 'should not' under the other module. It is likely that the 'should not' classification should be changed to 'may' rather than this section adjusted, as there's no good reason for not allowing its inclusion.">
             
-            <p>This operation must perform the following transformations:</p>
-        
-            <ol>
-                <li>If <var>original</var> section is not defined, it must be created as a copy of the <var>attributes</var> section.</li>
-                <li>If <var>attributes.propagate</var> is <var>false</var>, the value of <var>attributes.share</var> must be set <var>false</var>.</li>
-            </ol>
-            
-            <p>An implementation may define additional criteria for this operation.</p>
-            
-        </section>
-            
-        <section data-requirement="must" data-status="stub">
-            
-            <h1>AdjOutTransformJournal</h1>
-            
-        </section>
+        <p>This operation must perform the following transformations:</p>
 
-    </section>
-    
-    <section data-requirement="may">
-        
-        <h1>AdjOutStore</h1>
-        
-        <p>The <dfn>AdjOutStore</dfn> structure is a persistent data store that contains <a href='module/payloads#localpayload'><var>LocalPayload</var> (Payload Module)</a> objects. A payload stored in this structure must first have been processed through <a href='#adjouttransform'><var>AdjOutTransform</var></a>.</p>
-        
-        <p data-status='non-normative'>Payloads arrive at this structure via the <a href="#data-path">data path</a> from either <a href="module/receiver#adjinstore"><var>AdjInStore</var> (Receiver Module)</a> or <a href="module/local#localstore"><var>LocalStore</var> (Local Module)</a>.</p>
-        
-        <section data-requirement='must'>
-            
-            <h1>Required Operations</h1>
-        
-            <p>This structure must support two operations:</p>
+        <ol>
+            <li>If <var>original</var> section is not defined, it must be created as a copy of the <var>attributes</var> section.</li>
+            <li>If <var>attributes.propagate</var> is <var>false</var>, the value of <var>attributes.share</var> must be set <var>false</var>.</li>
+        </ol>
 
-            <dl>
-                <dt data-ref='adjinstore-create'>AdjOutStore::create(LocalPayload)</dt>
-                <dd>Stores a new record in persistence; must not create a record if any record already exists in persistence with the same <var>identity</var> as the new record.</dd>
-                <dt data-ref='adjinstore-get'>AdjOutStore::get(PayloadIdentity)</dt>
-                <dd>Gets a record from persistence that matches the <a href='module/payload#payloadidentity'><var>PayloadIdentity</var> (Payload Module)</a> passed to this method, or if no identity is passed, returns all payloads; must return false if identity was specified and no payload exists matching identity.</dd>
-                <dt data-ref='adjoutstore-get_all'>AdjOutStore::get_all()</dt>
-                <dd>Gets all records from persistence as an array of objects; must return an empty array if no payloads exist in persistence.</dd>
-            </dl>
-        
-            <p data-status='non-normative'>This structure will not store two payloads with identical <var>identity</var> sections.</p>
-            
-            <p>The <var>create</var> operation must not be used in any way except as defined by this protocol and its modules.</p>
-            
-            <p data-status='non-normative'>To add a payload for propagation via <a href='module/publisher#sendout'><var>SendOut</var> (Publisher Module)</a>, it must originate from <var>AdjInStore</var> or <var>LocalStore</var>. It must not be added directly to <var>AdjOutStore</var>, as this would imply that the payload neither originated locally nor was propagated from another system.</p>
-        
-        </section>
-        
-        <section data-requirement='should'>
-            
-            <h1>Additional Operations</h1>
-        
-            <p>This structure should support two additional operations:</p>
-        
-            <dl>
-                <dt data-ref='adjinstore-update'>AdjOutStore::update(LocalPayload)</dt>
-                <dd>Updates an existing payload record in persistence; must identify the payload to update by finding an existing record in persistence with the same <var>identity</var> attribute.</dd>
-                <dt data-ref='adjinstore-get'>AdjOutStore::delete(PayloadIdentity)</dt>
-                <dd>Deletes a record from persistence that matches the <a href='module/payload#payloadidentity'><var>PayloadIdentity</var> (Payload Module)</a> passed to this method.</dd>
-            </dl>
-            
-            <p>The <var>update</var> and <var>delete</var> operations must not be used in any way except as defined by this protocol and its modules.</p>
-            
-            <p data-status='non-normative'>To change the way a payload is presented via <a href='module/publisher#sendout'><var>SendOut</var> (Publisher Module)</a>, use <a href='#adjouttransform'><var>AdjOutTransform</var></a>. A payload must never be updated directly within this structure.</p>
-        
-            <p>The <var>delete</var> operation should be used to prune out stale entries.</p>
-            
-            <p data-status='non-normative'>To prevent a payload from being presented via <a href='module/publisher#sendout'><var>SendOut</var> (Publisher Module)</a>, use <a href='#adjoutfilter'><var>AdjOutFilter</var></a>. A payload must not be prevented from being presented by <var>AdjOutStore::delete()</var>.</p>
-        
+        <p>An implementation may define additional criteria for this operation.</p>
+
     </section>
     
     <section data-requirement="must">
@@ -176,20 +109,6 @@
         </ol>
         
         <p>An implementation may define additional criteria for this operation.</p>
-            
-        <section data-requirement="should" data-status="stub">
-
-            <h1>AdjOutFilterRules</h1>
-            
-            <p>The <var>AdjOutFilterRules</var> structure may be implemented as a methodology for specifying filter rules.</p>
-            
-            <section data-status="non-normative">
-                
-                <p>While implementations may add AdjOutFilter constraints internally, this structure is useful for allowing outlet- or user- defined rules, such as via the <a href="module/manager#OutletReceiveAdjOutFilterRules"><var>OutletReceiveAdjOutFilterRules</var> (Manager Module)</a> operation.</p>
-                
-            </section>
-
-        </section>
         
     </section>
     

--- a/support/schema.json
+++ b/support/schema.json
@@ -182,6 +182,79 @@
                   "originator_id"
                ]
             },
+            "original":{
+               "title":"PayloadLocalAttributes",
+               "type":"object",
+               "properties":{
+                  "timestamp":{
+                     "type":"string",
+                     "format":"date-time"
+                  },
+                  "uri":{
+                     "type":"string",
+                     "format":"uri"
+                  },
+                  "share":{
+                     "type":"boolean",
+                     "default":true
+                  },
+                  "propagate":{
+                     "type":"boolean",
+                     "default":true
+                  },
+                  "use":{
+                     "type":"object",
+                     "default":{
+
+                     }
+                  },
+                  "require":{
+                     "type":"object",
+                     "default":{
+
+                     }
+                  }
+               },
+               "required":[
+                  "timestamp",
+                  "uri",
+                  "share",
+                  "propagate"
+               ]
+            },
+            "journal":{
+               "type":"array",
+               "items":{
+                  "title":"PayloadLocalJournalEntry",
+                  "type":"object",
+                  "properties":{
+                     "originator_id":{
+                        "type":"string",
+                        "pattern":"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+                     },
+                     "timestamp":{
+                        "type":"string",
+                        "format":"date-time"
+                     },
+                     "use":{
+                        "type":"object",
+                        "default":{
+
+                        }
+                     },
+                     "require":{
+                        "type":"object",
+                        "default":{
+
+                        }
+                     }
+                  },
+                  "required":[
+                     "originator_id",
+                     "timestamp"
+                  ]
+               }
+            },
             "attributes":{
                "title":"PayloadLocalAttributes",
                "type":"object",
@@ -871,6 +944,74 @@
                      "timestamp"
                   ]
                }
+            },
+            "attributes":{
+               "title":"PayloadTransitAttributes",
+               "type":"object",
+               "properties":{
+                  "timestamp":{
+                     "type":"string",
+                     "format":"date-time"
+                  },
+                  "uri":{
+                     "type":"string",
+                     "format":"uri"
+                  },
+                  "share":{
+                     "type":"boolean",
+                     "default":true
+                  },
+                  "propagate":{
+                     "type":"boolean",
+                     "default":true
+                  },
+                  "use":{
+                     "type":"object",
+                     "patternProperties":{
+                        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$":{
+                           "type":[
+                              "array",
+                              "boolean",
+                              "integer",
+                              "null",
+                              "number",
+                              "object",
+                              "string"
+                           ]
+                        }
+                     },
+                     "additionalProperties":false,
+                     "default":{
+
+                     }
+                  },
+                  "require":{
+                     "type":"object",
+                     "patternProperties":{
+                        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$":{
+                           "type":[
+                              "array",
+                              "boolean",
+                              "integer",
+                              "null",
+                              "number",
+                              "object",
+                              "string"
+                           ]
+                        }
+                     },
+                     "additionalProperties":false,
+                     "default":{
+
+                     }
+                  }
+               },
+               "required":[
+                  "timestamp",
+                  "uri",
+                  "share",
+                  "propagate"
+               ]
             }
          },
          "required":[


### PR DESCRIPTION
Do not merge at this time. Work is ongoing on this branch. It exists to track the work in progress.

Changes, in a more human-readable way than the commit log (will be updated over time):
1. Change `attributes` in `TransitPayload` from "should not" to "may"
2. Explicitly allow for sending `original` and `journal` in `LocalPayload`
3. Remove `AdjOutPeer` from the Publisher Module
4. Make access control in Publisher Module part of the processing a response section
5. Remove `AdjInPeer` from the Receiver Module
6. Make access control in Receiver Module part of the sending a request section
7. Remove `AdjInStore` from the Receiver Module
8. Remove `AdjInFilterRules` from the Receiver Module
9. Remove `AdjOutStore` from the Relay Module
10. Remove `AdjOutTransformJournal` from the Relay Module
11. Remove `AdjOutFilterRules` from the Relay Module
12. Improve description of `AdjOutTransform` in the Relay Module
13. Remove `LocalStore`from the Local Module
14. Remove `AdjInToLocalStore` from the Local Module
15. Remove `LocalToAdjOutStore` from the Local Module
